### PR TITLE
Update README.md

### DIFF
--- a/packages/mobx-flux-react/README.md
+++ b/packages/mobx-flux-react/README.md
@@ -100,14 +100,14 @@ Wrap to CreateStoreProvider your app
 // ~/main.tsx
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
-import {CreateStoreProvider} from 'mobx-flux-react'
+import {Provider} from 'mobx-flux-react'
 import {store} from './store'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <>
-        <CreateStoreProvider store={store}>
+        <Provider store={store}>
             <App />
-        </CreateStoreProvider>
+        </Provider>
     </>,
 )
 ```


### PR DESCRIPTION
CreateStoreProvider is not found in 'mobx-flux-react', Provider imported instead.